### PR TITLE
put objectobserve above setimmediate

### DIFF
--- a/lib/polyfills.js
+++ b/lib/polyfills.js
@@ -54,6 +54,17 @@ Polyfill.register({
   }
 })
 
+// write here looks disharmony. objectobserve need native setImmediate for performance.
+// http://kangax.github.io/compat-table/es7/
+Polyfill.register({
+  name: 'objectobserve',
+  shortName: 'oobs',
+  url: '/jdarling/Object.observe/master/Object.observe.poly.js',
+  browsers: {
+    chrome: 33
+  }
+})
+
 // https://developer.mozilla.org/en-US/docs/Web/API/Window.setImmediate
 Polyfill.register({
   name: 'setimmediate',
@@ -272,15 +283,5 @@ Polyfill.register({
   browsers: {
     ff: 31,
     chrome: 34,
-  }
-})
-
-// http://kangax.github.io/compat-table/es7/
-Polyfill.register({
-  name: 'objectobserve',
-  shortName: 'oobs',
-  url: '/jdarling/Object.observe/master/Object.observe.poly.js',
-  browsers: {
-    chrome: 33
   }
 })

--- a/test/index.js
+++ b/test/index.js
@@ -194,4 +194,12 @@ describe('Polyfills', function () {
       assert(raf.filter(agent))
     })
   })
+
+  describe('objectobserve', function () {
+    it('above setimmediate', function () {
+      var oidx = db.polyfills.polyfills.indexOf(db.polyfills.polyfill.oobs)
+      var sidx = db.polyfills.polyfills.indexOf(db.polyfills.polyfill.si)
+      assert(oidx < sidx)
+    })
+  })
 })


### PR DESCRIPTION
objectobserve need native setImmediate for performance.

in my browser (safari 7.0.6 / osx 10.9.4). setimmediate use post message simulate delay callback.
objectobserve doesn't know this setImmediate method is fake and abuse it in looping.
put objectobserve above setimmediate. make objectobserve use setTimeout(10) in ?old? browser.

which browser support setImmediate? i even cannot find a browser to test it.
maybe objectobserve need a way to test if setImmediate is native.
